### PR TITLE
Remove future parser option

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -1,6 +1,6 @@
 CHECK_PUPPET_LINT="enabled" # enabled, permissive or disabled (permissive runs but return code is ignored)
 CHECK_PUPPET_DOCS="enabled" # enabled, permissive or disabled (permissive runs but return code is ignored)
-USE_PUPPET_FUTURE_PARSER="enabled" # enabled or disabled
+USE_PUPPET_FUTURE_PARSER="disabled" # enabled or disabled
 CHECK_INITIAL_COMMIT="disabled" # enabled or disabled
 CHECK_RSPEC="enabled" # enabled or disabled
 export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-140chars-check"


### PR DESCRIPTION
This avoids errors like:
Error: Could not parse application options: invalid option: --parser
Error: puppet syntax error in .... 
due to the fact that on current Puppet version the --parser option is no longer valid